### PR TITLE
Fix: launchctl dubious permissions error

### DIFF
--- a/src/cli/commands/start.coffee
+++ b/src/cli/commands/start.coffee
@@ -15,5 +15,7 @@ module.exports = ->
     emitter.emit 'error', "#{config.launchAgentsPath} doesn't exist"
 
   shell.to "#{config.launchAgentsPath}/katon.plist", plistContent
+  # make sure the .plist file have correct permissions
+  chmod 644, "#{config.launchAgentsPath}/katon.plist"
   shell.exec "launchctl load -Fw #{config.launchAgentsPath}/katon.plist"
   emitter.emit 'info', 'Katon daemon was successfully started'

--- a/test/cli/commands/start.coffee
+++ b/test/cli/commands/start.coffee
@@ -2,6 +2,7 @@ assert = require 'assert'
 config = require '../test_config'
 emitter = require '../../../src/cli/util/emitter'
 start = require '../../../src/cli/commands/start'
+fs = require 'fs'
 
 describe 'start()', ->
 
@@ -14,3 +15,6 @@ describe 'start()', ->
 
   it 'should put a katon.plist in config.launchAgentsPath', ->
     assert test '-e', "#{config.launchAgentsPath}/katon.plist"
+  
+  it 'should set the correct permissions on the katon.plist file'
+    # pending test


### PR DESCRIPTION
This simple patch fixes a file permissions error on Mac OS X (10.8 & 10.9) for the katon.plist file.

When trying:
    $ katon restart

reports the following error with the file permissions on the katon.plist file:

```
$   launchctl: Dubious permissions on file (skipping): /Users/USERNAME/Library/LaunchAgents/katon.plist
$   nothing found to unload
```

Hopefully it's useful.
