### PR TITLE
fixed typo 'siltent'

### DIFF
--- a/src/cli/util/shell.coffee
+++ b/src/cli/util/shell.coffee
@@ -16,7 +16,7 @@ module.exports.rm = (file) ->
   rm file
   emitter.emit 'debug', "rm #{file}"
 
-module.exports.exec = (command, options = siltent: true) ->
+module.exports.exec = (command, options = silent: true) ->
   res = exec command, options
   emitter.emit 'debug', command
   if res.code > 0


### PR DESCRIPTION
Fixes simple typo in the shell exec helper
