### PR TITLE
change subdomain handling

### DIFF
--- a/src/daemon/http-router.js
+++ b/src/daemon/http-router.js
@@ -11,7 +11,7 @@ function log(id, msg) {
 }
 
 function getId(host) {
-  return host.split('.').slice(-2, -1).pop()
+  return host.split('.').slice(0, -1).join('.')
 }
 
 module.exports.createServer = function() {
@@ -40,7 +40,7 @@ module.exports.createServer = function() {
         catch(e) { log(id, e) }
 
         var delay = 2000
-        
+
         log(id, 'Forwarding to ' + port)
         proxy.web(req, res, target, function() {
           log(id, 'Failed to forward, retry in ' + delay + ' ms')
@@ -54,7 +54,7 @@ module.exports.createServer = function() {
           }, delay)
         })
 
-        timer(proc.id, function() { 
+        timer(proc.id, function() {
           log(id, 'No requests for 1 hour')
           proc.stop()
         })
@@ -65,7 +65,7 @@ module.exports.createServer = function() {
 
         res.statusCode = 404
         res.end(render('404.html'))
-      
+
       }
 
     } else {
@@ -85,7 +85,7 @@ module.exports.createServer = function() {
     }
 
     var id = getId(req.headers.host)
-    
+
     log(id, 'Can\'t connect: ' + err)
     res.statusCode = 502
     res.end(render('502.html'))

--- a/test/daemon/fixtures/subdomain.node/index.js
+++ b/test/daemon/fixtures/subdomain.node/index.js
@@ -1,0 +1,9 @@
+var http = require('http')
+
+http.createServer(function (req, res) {
+  console.log('Received a request')
+  res.writeHead(200, {'Content-Type': 'text/plain'})
+  res.end('OK');
+}).listen(process.env.PORT, function() {
+  console.log('listening on port', process.env.PORT)
+})

--- a/test/daemon/index.js
+++ b/test/daemon/index.js
@@ -40,6 +40,23 @@ describe('Katon', function() {
     }, done)
   })
 
+  it('Add node > GET http://subdomain.node.ka', function(done) {
+    helper.add('subdomain.node', 'node index.js')
+
+    helper.GET('subdomain.node.ka', {
+      status: 200,
+      body: 'OK'
+    }, done)
+  })
+
+  it('Add node > GET http://subdomain.node.ka', function(done) {
+    helper.add('node', 'node index.js')
+
+    helper.GET('notsubdomain.node.ka', {
+      status: 404
+    }, done)
+  })
+
   it('Add node-slow > GET http://node-slow.ka', function(done) {
     helper.add('node-slow', 'node index.js')
 


### PR DESCRIPTION
allows for different subdomains to map to different procs. not sure why
the behavior was ever any different — i don’t find it idiomatic at all
to allow for ‘foo.bar.com’ and ‘baz.bar.com’ to both hit the same app.
