### PR TITLE
Web tail

### DIFF
--- a/src/cli/commands/tail.js
+++ b/src/cli/commands/tail.js
@@ -9,15 +9,20 @@ var INITIAL_LINES = 10
 module.exports = function(args) {
   var host  = args[0] || pathToHost(process.cwd())
   var tail  = new Tail(host, INITIAL_LINES);
-  tail.on('error', function(error) {
-    process.stderr.write(chalk.red(error.message) + '\n')
-    process.exit(1)
-  })
-  tail.on('line', function(prefix, line) {
-    if (prefix)
-      process.stdout.write(chalk.blue('[' + prefix + ']  '))
-    process.stdout.write(line + '\n')
-  })
+  tail
+    .on('line', function(prefix, line) {
+      if (prefix)
+        process.stdout.write(chalk.blue('[' + prefix + ']  '))
+      process.stdout.write(line + '\n')
+    })
+    .on('error', function(error) {
+      process.stderr.write(chalk.red(error.message) + '\n')
+      process.exit(1)
+    })
   tail.start()
+
+  // Keep process running until Ctrl+C
+  setInterval(function() {
+  }, 1000)
 }
 

--- a/src/cli/commands/tail.js
+++ b/src/cli/commands/tail.js
@@ -14,7 +14,7 @@ var INITIAL_LINES = 10
 function tailStream(filename, prefix, position) {
   var streamOptions = {
     start:    position,
-    encoding: 'utf-8'
+    encoding: 'utf8'
   }
   var stream = fs.createReadStream(filename, streamOptions)
 
@@ -64,7 +64,7 @@ function watchFile(filename, prefix, position) {
 // This function dumps the end of the existing log file, and then starts
 // watching for changes.
 function tailFile(filename, prefix) {
-  var stream    = fs.createReadStream(filename, 'utf-8')
+  var stream    = fs.createReadStream(filename, { encoding: 'utf8' })
   var lines     = []
   var buffer    = ''
   var position  = 0

--- a/src/cli/commands/tail.js
+++ b/src/cli/commands/tail.js
@@ -1,125 +1,23 @@
-var fs         = require('fs')
-var chalk      = require('chalk')
-var path       = require('path')
-var pathToHost = require('../utils/path-to-host')
-var config     = require('../../config.js')
+var chalk       = require('chalk')
+var Tail        = require('../../daemon/utils/tail')
+var pathToHost  = require('../utils/path-to-host')
 
 
 // Number of lines to show from end of log.
 var INITIAL_LINES = 10
 
-
-// Tail the end of the stream from the previous position.  When done, go back
-// to watching the file for changes.
-function tailStream(filename, prefix, position) {
-  var streamOptions = {
-    start:    position,
-    encoding: 'utf8'
-  }
-  var stream = fs.createReadStream(filename, streamOptions)
-
-  var lastLine = ''
-  stream.on('data', function(chunk) {
-    var buffer = lastLine + chunk
-    var lines  = buffer.split(/\n/)
-    lastLine   = lines.pop()
-    for (var i in lines) {
-      var line = lines[i] + '\n'
-      process.stdout.write(prefix + line)
-      position += line.length
-    }
-  })
-
-  stream.on('end', function() {
-    watchFile(filename, prefix, position)
-  })
-  stream.on('error', function(error) {
-    watchFile(filename, prefix, position)
-  })
-}
-
-
-// Watch file for changes.  When Katon appends to file we get a change event
-// and read from previous position forward.
-function watchFile(filename, prefix, position) {
-  try {
-    var watcher = fs.watch(filename, function(event) {
-      var stats = fs.statSync(filename)
-      if (stats.size < position) {
-        // File got truncated need to adjust position to new end of file
-        position = stats.size
-      } else if (stats.size > position) {
-        // File has more content, stop watching while we tail the stream
-        watcher.close()
-        tailStream(filename, prefix, position)
-      }
-    })
-  } catch (error) {
-    console.log(chalk.red("Cannot tail %s, start server and try again"), filename)
-    process.exit(1)
-  }
-}
-
-
-// This function dumps the end of the existing log file, and then starts
-// watching for changes.
-function tailFile(filename, prefix) {
-  var stream    = fs.createReadStream(filename, { encoding: 'utf8' })
-  var lines     = []
-  var buffer    = ''
-  var position  = 0
-  stream.on('data', function(chunk) {
-    buffer += chunk
-    // Parse stream into lines and keep the last INITIAL_LINES in memory.
-    // Make sure position points to the last byte in the file, or the first
-    // byte of the last incomplete line.
-    var match
-    while (match = buffer.match(/^.*\n/)) {
-      var line = match[0]
-      lines.push(line)
-      position += line.length
-      buffer    = buffer.slice(line.length)
-    }
-    lines = lines.slice(-INITIAL_LINES)
-  })
-  stream.on('end', function() {
-    // Dump the tail of the log to the console and start watching for changes.
-    //for (var i = 0; i < lines.length ; ++i)
-    for (var i in lines)
-      process.stdout.write(prefix + lines[i])
-    watchFile(filename, prefix, position)
-  })
-  stream.on('error', function(error) {
-    console.log(chalk.red("Cannot tail %s, start server and try again"), filename)
-    process.exit(1)
-  })
-}
-
-
-// Tail all log files from the logs directory
-function tailAllLogFiles()
-{
-  fs.readdirSync(config.logsDir)
-    .filter(function(filename) {
-      return /\.log$/.test(filename)
-    })
-    .map(function(filename) {
-      return config.logsDir + '/' + filename
-    })
-    .forEach(function(filename) {
-      var basename = path.basename(filename, '.log')
-      var prefix   = chalk.blue('[' + basename + ']  ')
-      tailFile(filename, prefix)
-    })
-}
-
-
 module.exports = function(args) {
-  var host    = args[0] || pathToHost(process.cwd())
-  var logFile = config.logsDir + '/' + host + '.log'
-
-  if (host == 'all')
-    tailAllLogFiles()
-  else
-    tailFile(logFile, '')
+  var host  = args[0] || pathToHost(process.cwd())
+  var tail  = new Tail(host, INITIAL_LINES);
+  tail.on('error', function(error) {
+    process.stderr.write(chalk.red(error.message) + '\n')
+    process.exit(1)
+  })
+  tail.on('line', function(prefix, line) {
+    if (prefix)
+      process.stdout.write(chalk.blue('[' + prefix + ']  '))
+    process.stdout.write(line + '\n')
+  })
+  tail.start()
 }
+

--- a/src/daemon/http-router.js
+++ b/src/daemon/http-router.js
@@ -80,13 +80,17 @@ function tailSSE(res) {
     'Connection':     'keep-alive'
   });
   var tail = new Tail('all', 10)
-  tail.on('line', function(prefix, line) {
-    var message = {
-      prefix: prefix,
-      line:   line.replace(/\[\d{2}m/g, '')
-    }
-    res.write('event: line\ndata: ' + JSON.stringify(message) + '\n\n');
-  })
+  tail
+    .on('line', function(prefix, line) {
+      var message = {
+        prefix: prefix,
+        line:   line.replace(/\[\d{2}m/g, '')
+      }
+      res.write('event: line\ndata: ' + JSON.stringify(message) + '\n\n');
+    })
+    .on('error', function(error) {
+      log('all', 'Cannot tail logs', error)
+    })
   res.on('close', function() {
     tail.stop()
   })

--- a/src/daemon/http-router.js
+++ b/src/daemon/http-router.js
@@ -79,13 +79,16 @@ function tailSSE(res) {
     'Cache-Control':  'no-cache',
     'Connection':     'keep-alive'
   });
-  var tail = new Tail()
+  var tail = new Tail('all', 10)
   tail.on('line', function(prefix, line) {
     var message = {
       prefix: prefix,
       line:   line.replace(/\[\d{2}m/g, '')
     }
     res.write('event: line\ndata: ' + JSON.stringify(message) + '\n\n');
+  })
+  res.on('close', function() {
+    tail.stop()
   })
   tail.start()
 }

--- a/src/daemon/templates/200.html
+++ b/src/daemon/templates/200.html
@@ -24,3 +24,23 @@
 </table>
 
 <p><em>* xip.io is a wildcard DNS service, you can use these addresses to access your development web server from devices on your local network, like iPads, iPhones, and other computers.</em></p>
+<pre id="tail" class="pre-scrollable"></pre>
+
+<script>
+var tail   = document.getElementById('tail');
+var source = new EventSource('/tail');
+source.addEventListener('line', function(event) {
+  var message         = JSON.parse(event.data);
+  var entry           = document.createElement('div')
+  var prefix          = document.createElement('span')
+  prefix.textContent  = message.prefix + ':  '
+  prefix.className    = 'text-primary'
+  entry.appendChild(prefix)
+  var line            = document.createElement('span')
+  line.className      = 'text-nowrap'
+  line.textContent    = message.line
+  entry.appendChild(line)
+  tail.appendChild(entry)
+  tail.scrollTop      = entry.offsetTop
+});
+</script>

--- a/src/daemon/utils/tail.js
+++ b/src/daemon/utils/tail.js
@@ -1,0 +1,152 @@
+var Events      = require('events')
+var fs          = require('fs')
+var path        = require('path')
+var config      = require('../../config.js')
+var Util        = require('util')
+
+
+function Tail(host, initialLines) {
+  this.host         = host || 'all'
+  this.initialLines = initialLines
+  this.tailing      = false
+}
+Util.inherits(Tail, Events.EventEmitter)
+
+
+// Call this to start tailing
+Tail.prototype.start = function() {
+  if (this.tailing)
+    return
+
+  if (this.host == 'all') {
+    this.tailAllLogFiles()
+  } else {
+    var logFile = config.logsDir + '/' + this.host + '.log'
+    this.tailFile(logFile)
+  }
+  this.tailing = true
+}
+
+
+// Call this to end tailing
+Tail.prototype.stop = function() {
+  this.tailing = false
+}
+
+
+// -- Tail log files --
+
+// Tail all log files from the logs directory
+Tail.prototype.tailAllLogFiles = function() {
+  var tail = this
+  fs.readdirSync(config.logsDir)
+    .filter(function(filename) {
+      return /\.log$/.test(filename)
+    })
+    .map(function(filename) {
+      return config.logsDir + '/' + filename
+    })
+    .forEach(function(filename) {
+      var prefix = path.basename(filename, '.log')
+      tail.tailFile(filename, prefix)
+    })
+}
+
+// This function dumps the end of the existing log file, and then starts
+// watching for changes.
+Tail.prototype.tailFile = function(filename, prefix) {
+  var tail      = this
+  var stream    = fs.createReadStream(filename, { encoding: 'utf8' })
+  var lines     = []
+  var buffer    = ''
+  var position  = 0
+  stream.on('data', function(chunk) {
+    buffer += chunk
+    // Parse stream into lines and keep the last INITIAL_LINES in memory.
+    // Make sure position points to the last byte in the file, or the first
+    // byte of the last incomplete line.
+    var match
+    while (match = buffer.match(/^.*\n/)) {
+      var line = match[0]
+      lines.push(line.slice(0, -1))
+      position += line.length
+      buffer    = buffer.slice(line.length)
+    }
+    lines = lines.slice(-this.initialLines)
+  })
+  stream.on('end', function() {
+    // Dump the tail of the log to the console and start watching for changes.
+    //for (var i = 0; i < lines.length ; ++i)
+    for (var i in lines) {
+      tail.emit('line', prefix, lines[i])
+    }
+    if (tail.tailing)
+      tail.watchFile(filename, prefix, position)
+  })
+  stream.on('error', function(error) {
+    tail.emit('error', new Error("Cannot tail ' + filename + ', start server and try again"))
+  })
+}
+
+
+// Watch file for changes.  When Katon appends to file we get a change event
+// and read from previous position forward.
+Tail.prototype.watchFile = function(filename, prefix, position) {
+  var tail = this
+  try {
+    var watcher = fs.watch(filename, function(event) {
+      if (!tail.tailing)
+        return
+
+      var stats = fs.statSync(filename)
+      if (stats.size < position) {
+        // File got truncated need to adjust position to new end of file
+        position = stats.size
+      } else if (stats.size > position) {
+        // File has more content, stop watching while we tail the stream
+        watcher.close()
+        tail.tailStream(filename, prefix, position)
+      }
+    })
+  } catch (error) {
+    tail.emit('error', new Error('Cannot tail ' + filename + ', start server and try again'))
+  }
+}
+
+
+// Tail the end of the stream from the previous position.  When done, go back
+// to watching the file for changes.
+Tail.prototype.tailStream = function(filename, prefix, position) {
+  var tail          = this
+  var streamOptions = {
+    start:    position,
+    encoding: 'utf8'
+  }
+  var stream        = fs.createReadStream(filename, streamOptions)
+  var lastLine      = ''
+  stream.on('data', function(chunk) {
+    if (!tail.tailing) {
+      stream.close()
+      return
+    }
+
+    var buffer = lastLine + chunk
+    var lines  = buffer.split(/\n/)
+    lastLine   = lines.pop()
+    for (var i in lines) {
+      var line = lines[i]
+      tail.emit('line', prefix, line)
+      position += line.length + 1
+    }
+  })
+
+  stream.on('end', function() {
+    tail.watchFile(filename, prefix, position)
+  })
+  stream.on('error', function(error) {
+    tail.watchFile(filename, prefix, position)
+  })
+}
+
+
+module.exports = Tail

--- a/src/daemon/utils/tail.js
+++ b/src/daemon/utils/tail.js
@@ -39,7 +39,7 @@ Tail.prototype.start = function() {
 
 // Call this to end tailing
 Tail.prototype.stop = function() {
-  log('Stopped tailing')
+  // log('Stopped tailing')
   this.logFiles.forEach(function(logFile) {
     logFile.stop()
   })
@@ -81,7 +81,7 @@ function LogFile(tail, filename, host) {
 
 LogFile.prototype.start = function() {
   var logFile   = this
-  log('Tailing ' + logFile.filename)
+  //log('Tailing ' + logFile.filename)
 
   var stream    = fs.createReadStream(logFile.filename, { encoding: 'utf8' })
   var lines     = []
@@ -108,7 +108,6 @@ LogFile.prototype.start = function() {
     logFile.watch()
   })
   stream.on('error', function(error) {
-    log('Error tailing ' + logFile.filename, error)
     logFile.emit('error', new Error('Cannot tail ' + logFile.filename + ', start server and try again'))
   })
 }
@@ -159,6 +158,9 @@ LogFile.prototype.tailStream = function(callback) {
     }
   })
   stream.on('end', callback);
+  stream.on('error', function(error) {
+    logFile.emit('error', new Error('Cannot tail ' + logFile.filename + ', start server and try again'))
+  })
 }
 
 


### PR DESCRIPTION
This is an attempt to show the consolidate log from within `index.ka`, just under the list of deployed applications.

It adds a new endpoint `index.ka/tail` which uses server-sent events to stream the log to the browser, one log line at a time.

The tailing code, originally written for `katon tail`, was extracted into a separate module. It exports a class with two primary methods: `start` and `stop` (the web endpoint needs to stop tailing when browser drops connection). It emits the events `line` and `error`.

UI is pretty simplistic, just putting it out there as starting point.

I tested this on io.js 1.5.1