### PR TITLE
In console tail, each app gets its own color.

### DIFF
--- a/src/cli/commands/tail.js
+++ b/src/cli/commands/tail.js
@@ -28,6 +28,20 @@ function getHostName(cwd) {
   return hostNames[0]
 }
 
+var COLORS = ['blue', 'magenta', 'green', 'yellow', 'cyan', 'gray'];
+var mappingColors = {};
+var idx = 0;
+
+function colorPrefix (prefix) {
+  if (!mappingColors.hasOwnProperty(prefix)) {
+    if (idx >= COLORS.length) {
+      idx = 0;
+    }
+    mappingColors[prefix] = COLORS[idx++];
+  }
+  return chalk[mappingColors[prefix]](prefix);
+}
+
 
 module.exports = function(args) {
   var host  = args[0] || getHostName(process.cwd())
@@ -35,7 +49,7 @@ module.exports = function(args) {
   tail
     .on('line', function(prefix, line) {
       if (prefix)
-        process.stdout.write(chalk.blue('[' + prefix + ']  '))
+        process.stdout.write(colorPrefix('[' + prefix + ']  '))
       process.stdout.write(line + '\n')
     })
     .on('error', function(error) {


### PR DESCRIPTION
Instead of coloring all the prefix (the app name) in blue, we assign a different color to each app. If more than 6, we might assign the same color to two apps.

Useful for me anyway. You might want to pull it.